### PR TITLE
Bump version numbers and fix up warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "small-map"
 version = "0.1.3"
-edition = "2024"
+edition = "2021"
 
 authors = ["ChiHai <ihciah@gmail.com>"]
 categories = ["data-structures"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "small-map"
 version = "0.1.3"
-edition = "2021"
+edition = "2024"
 
 authors = ["ChiHai <ihciah@gmail.com>"]
 categories = ["data-structures"]
@@ -12,19 +12,21 @@ readme = "README.md"
 repository = "https://github.com/ihciah/small-map"
 
 [dependencies]
-hashbrown = { version = "0.14", features = [
+hashbrown = { version = "0.15.4", features = [
     "inline-more",
     "allocator-api2",
 ], default-features = false }
 
 serde = { version = "1", default-features = false, optional = true }
 ahash = { version = "0.8", default-features = false, optional = true }
-rustc-hash = { version = "1", default-features = false, optional = true }
+rustc-hash = { version = "2.1.1", default-features = false, optional = true }
 
 [dev-dependencies]
-rand = { version = "0.8" }
-criterion = { version = "0.5", features = ["html_reports"] }
-pprof = { version = "0.13", features = ["flamegraph"] }
+rand = { version = "0.9.1" }
+criterion = { version = "0.6.0", features = ["html_reports"] }
+
+[target.'cfg(unix)'.dev-dependencies]
+pprof = { version = "0.15.0", features = ["flamegraph"] }
 
 [features]
 default = ["hashes"]

--- a/benches/simple.rs
+++ b/benches/simple.rs
@@ -1,4 +1,6 @@
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use std::hint::black_box;
+
+use criterion::{criterion_group, criterion_main, Criterion};
 
 fn smallmap<const N: usize>(n: u8) {
     let mut map = small_map::SmallMap::<N, _, _>::default();
@@ -55,6 +57,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     c.bench_function("stdhashmap-simple-16", |b| b.iter(|| std_hashmap(16)));
 }
 
+#[cfg(unix)]
 mod profile {
     use std::{fs::File, path::Path};
 
@@ -100,6 +103,7 @@ mod profile {
 
 criterion_main!(benches);
 criterion_group!(benches, criterion_benchmark);
+//#[cfg(unix)]
 // criterion_group! {
 //     name = benches;
 //     // This can be any expression that returns a `Criterion` object.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -220,7 +220,8 @@ where
                             SmallMap::Inline(_) => unsafe { unreachable_unchecked() },
                         };
                         for (k, v) in inline.into_iter() {
-                            heap.insert_unique_unchecked(k, v);
+                            // Safety: Heap is new, so each K is unique (as long as all keys in Inline are unique)
+                            unsafe { heap.insert_unique_unchecked(k, v); }
                         }
                         heap
                     }
@@ -488,7 +489,7 @@ mod tests {
     #[test]
     fn fuzzing() {
         let mut smallmap = SmallMap::<16, i32, i32>::default();
-        let mut hashmap = HashMap::<i32, i32, RandomState>::default();
+        let mut hashmap = HashMap::<i32, i32, RandomState>::with_hasher(RandomState::new());
         for _ in 0..1000000 {
             let op = Operation::random();
             op.exec(&mut smallmap, &mut hashmap);
@@ -504,12 +505,12 @@ mod tests {
             fn random() -> Self {
                 let mut rng = rand::thread_rng();
 
-                let choice: u8 = rng.gen();
+                let choice: u8 = rng.random();
                 match choice % 4 {
-                    0 => Operation::Insert(rng.gen_range(0..32), rng.gen()),
-                    1 => Operation::Remove(rng.gen_range(0..32)),
-                    2 => Operation::Get(rng.gen_range(0..32)),
-                    3 => Operation::ModifyIfExist(rng.gen_range(0..32), rng.gen()),
+                    0 => Operation::Insert(rng.random_range(0..32), rng.random()),
+                    1 => Operation::Remove(rng.random_range(0..32)),
+                    2 => Operation::Get(rng.random_range(0..32)),
+                    3 => Operation::ModifyIfExist(rng.random_range(0..32), rng.random()),
                     _ => unreachable!(),
                 }
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -503,7 +503,7 @@ mod tests {
         }
         impl Operation {
             fn random() -> Self {
-                let mut rng = rand::thread_rng();
+                let mut rng = rand::rng();
 
                 let choice: u8 = rng.random();
                 match choice % 4 {

--- a/src/raw/mod.rs
+++ b/src/raw/mod.rs
@@ -92,11 +92,11 @@ impl<T> RawIterInner<T> {
     unsafe fn next_impl(&mut self, group_base: NonNull<u8>, base: Bucket<T>) -> Bucket<T> {
         loop {
             if let Some(index) = self.current_group.next() {
-                return base.next_n(index + self.group_offset);
+                return unsafe { base.next_n(index + self.group_offset) };
             }
 
             self.group_offset += Group::WIDTH;
-            self.current_group = Group::load_aligned(group_base.as_ptr().add(self.group_offset))
+            self.current_group = unsafe { Group::load_aligned(group_base.as_ptr().add(self.group_offset)) }
                 .match_full()
                 .into_iter();
         }
@@ -126,7 +126,7 @@ impl<T> RawIterInner<T> {
     pub(crate) unsafe fn drop_elements(&mut self, group_base: NonNull<u8>, base: Bucket<T>) {
         if T::NEEDS_DROP && self.len != 0 {
             while let Some(item) = self.next(group_base, base.clone()) {
-                item.drop();
+                unsafe { item.drop(); }
             }
         }
     }

--- a/src/raw/sse2.rs
+++ b/src/raw/sse2.rs
@@ -48,7 +48,7 @@ impl Group {
     #[inline]
     #[allow(clippy::cast_ptr_alignment)] // unaligned load
     pub(crate) unsafe fn load(ptr: *const u8) -> Self {
-        Group(x86::_mm_loadu_si128(ptr.cast()))
+        Group(unsafe { x86::_mm_loadu_si128(ptr.cast()) })
     }
 
     /// Loads a group of bytes starting at the given address, which must be
@@ -58,7 +58,7 @@ impl Group {
     pub(crate) unsafe fn load_aligned(ptr: *const u8) -> Self {
         // FIXME: use align_offset once it stabilizes
         debug_assert_eq!(ptr as usize & (mem::align_of::<Self>() - 1), 0);
-        Group(x86::_mm_load_si128(ptr.cast()))
+        Group(unsafe { x86::_mm_load_si128(ptr.cast()) })
     }
 
     /// Returns a `BitMask` indicating all bytes in the group which have

--- a/src/raw/util.rs
+++ b/src/raw/util.rs
@@ -102,10 +102,10 @@ impl<T> Bucket<T> {
             // (see TableLayout::calculate_layout_for method)
             invalid_mut(index + 1)
         } else {
-            base.as_ptr().add(index)
+            unsafe { base.as_ptr().add(index) }
         };
         Self {
-            ptr: NonNull::new_unchecked(ptr),
+            ptr: unsafe { NonNull::new_unchecked(ptr) },
         }
     }
 
@@ -119,7 +119,7 @@ impl<T> Bucket<T> {
             // this can not be UB
             self.ptr.as_ptr() as usize - 1
         } else {
-            self.ptr.as_ptr().offset_from(base.as_ptr()) as usize
+            unsafe { self.ptr.as_ptr().offset_from(base.as_ptr()) as usize }
         }
     }
 
@@ -138,33 +138,33 @@ impl<T> Bucket<T> {
     /// Executes the destructor (if any) of the pointed-to `data`.
     #[inline]
     pub(crate) unsafe fn drop(&self) {
-        self.as_ptr().drop_in_place();
+        unsafe { self.as_ptr().drop_in_place(); }
     }
 
     /// Reads the `value` from `self` without moving it. This leaves the
     /// memory in `self` unchanged.
     #[inline]
     pub(crate) unsafe fn read(&self) -> T {
-        self.as_ptr().read()
+        unsafe { self.as_ptr().read() }
     }
 
     /// Overwrites a memory location with the given `value` without reading
     /// or dropping the old value (like [`ptr::write`] function).
     #[inline]
     pub(crate) unsafe fn write(&self, val: T) {
-        self.as_ptr().write(val);
+        unsafe { self.as_ptr().write(val); }
     }
 
     /// Returns a shared immutable reference to the `value`.
     #[inline]
     pub(crate) unsafe fn as_ref<'a>(&self) -> &'a T {
-        &*self.as_ptr()
+        unsafe { &*self.as_ptr() }
     }
 
     /// Returns a unique mutable reference to the `value`.
     #[inline]
     pub(crate) unsafe fn as_mut<'a>(&self) -> &'a mut T {
-        &mut *self.as_ptr()
+        unsafe { &mut *self.as_ptr() }
     }
 
     /// Create a new [`Bucket`] that is offset from the `self` by the given
@@ -177,10 +177,10 @@ impl<T> Bucket<T> {
             // invalid pointer is good enough for ZST
             invalid_mut(self.ptr.as_ptr() as usize)
         } else {
-            self.ptr.as_ptr().add(offset)
+            unsafe { self.ptr.as_ptr().add(offset) }
         };
         Self {
-            ptr: NonNull::new_unchecked(ptr),
+            ptr: unsafe { NonNull::new_unchecked(ptr) },
         }
     }
 }


### PR DESCRIPTION
* Bump version numbers to latest
* Fix up new warnings

# Maybe Controversial
I've updated rust `edition = "2024"` - what do you think?